### PR TITLE
Add Flask deployment for model

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: gunicorn src.app:app

--- a/README.md
+++ b/README.md
@@ -28,3 +28,19 @@ To generate and view detailed evaluation metrics and visualizations, follow thes
 2. Run the training script: `python src/train.py`
 3. After training, evaluation metrics will be saved in the `results/metrics.txt` file.
 4. Confusion matrix and ROC curve visualizations will be saved in the `results/` directory as `confusion_matrix.png` and `roc_curve.png` respectively.
+
+## Deploying the Model using Flask
+To deploy the model using Flask, follow these steps:
+1. Install the required dependencies: `pip install flask gunicorn`
+2. Create a `Procfile` in the root directory with the following content:
+   ```
+   web: gunicorn src.app:app
+   ```
+3. Create a new file `src/app.py` with the Flask application code.
+4. Deploy the application to Heroku or any other cloud platform that supports Flask.
+
+## Running the Flask App Locally
+To run the Flask app locally, follow these steps:
+1. Install the required dependencies: `pip install flask`
+2. Run the Flask app: `python src/app.py`
+3. Send a POST request to the `/predict` endpoint with the input data to get predictions.

--- a/src/app.py
+++ b/src/app.py
@@ -1,0 +1,26 @@
+from flask import Flask, request, jsonify
+import tensorflow as tf
+import numpy as np
+from src.data_loader import preprocess_data
+
+app = Flask(__name__)
+
+# Load the trained model
+model = tf.keras.models.load_model('models/trained_model.h5')
+
+@app.route('/predict', methods=['POST'])
+def predict():
+    data = request.get_json()
+    data = np.array(data['data'])
+    
+    # Preprocess the input data
+    X, _ = preprocess_data(data)
+    
+    # Make predictions
+    predictions = model.predict(X)
+    predictions = (predictions > 0.5).astype(int)
+    
+    return jsonify({'predictions': predictions.tolist()})
+
+if __name__ == '__main__':
+    app.run(debug=True)


### PR DESCRIPTION
Add Flask application for model deployment.

* Create `src/app.py` to define a Flask application, load the trained model, and define an endpoint for prediction.
* Add `Procfile` to specify the command to run the Flask app using `gunicorn`.
* Update `README.md` to include instructions for deploying the model using Flask and running the Flask app locally.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/akaday/OncoPredict?shareId=b2708c3a-978f-42fd-bcbb-a8954b31bc10).